### PR TITLE
Use the GDT_FIRST_TSS constant instead of hardcoding the magic value 6.

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -44,6 +44,7 @@ use logging::*;
 use consts::*;
 use x86::shared::task::load_tr;
 use x86::shared::segmentation::SegmentSelector;
+use x86::shared::PrivilegeLevel;
 
 extern {
 	/// Begin of the kernel.  Declared in `linker.ld` so that we can
@@ -125,8 +126,8 @@ pub fn replace_boot_stack(stack_bottom: usize, ist_bottom: usize)
 			ist_bottom + KERNEL_STACK_SIZE - 0x10);
 
 		// register task
-		let sel: u16 = 6 << 3;
-		load_tr(SegmentSelector::from_raw(sel));
+		let sel = SegmentSelector::new(gdt::GDT_FIRST_TSS as u16, PrivilegeLevel::Ring0);
+		load_tr(sel);
 	}
 }
 

--- a/src/arch/x86_64/gdt.rs
+++ b/src/arch/x86_64/gdt.rs
@@ -40,11 +40,11 @@ const GDT_KERNEL_DATA: usize = 2;
 const GDT_USER32_CODE: usize = 3;
 const GDT_USER32_DATA: usize = 4;
 const GDT_USER64_CODE: usize = 5;
-const GDT_FIRST_TSS:   usize = 6;
+pub const GDT_FIRST_TSS: usize = 6;
 
 // fox x86_64 is a TSS descriptor twice larger than a code/data descriptor
 const TSS_ENTRIES: usize = 2;
-const GDT_ENTRIES: usize = (6+TSS_ENTRIES);
+const GDT_ENTRIES: usize = (GDT_FIRST_TSS+TSS_ENTRIES);
 
 // thread_local on a static mut, signals that the value of this static may
 // change depending on the current thread.


### PR DESCRIPTION
This highly simplifies changing the number of descriptors later, as I already experienced with HermitCore.