### PR TITLE
Rework scheduler for easier initialization and add multi-level feedback

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -37,10 +37,10 @@ pub const CACHE_LINE : usize = 64;
 pub const PAGE_SIZE : usize = 4096;
 
 /// Maximum number of priorities
-pub const NO_PRIORITIES: usize = 32;
+pub const NO_PRIORITIES: usize = 256;
 
 /// penalty for multilevel feedback
-pub const SCHEDULING_PENALTY: u8 = 8;
+pub const SCHEDULING_PENALTY: i8 = 60;
 
 /// frequency of the timer interrupt
 pub const TIMER_FREQ: u32 = 100; /* in HZ */

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -39,5 +39,8 @@ pub const PAGE_SIZE : usize = 4096;
 /// Maximum number of priorities
 pub const NO_PRIORITIES: usize = 32;
 
+/// penalty for multilevel feedback
+pub const SCHEDULING_PENALTY: u8 = 8;
+
 /// frequency of the timer interrupt
 pub const TIMER_FREQ: u32 = 100; /* in HZ */

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -27,6 +27,7 @@
 //! Interface to the scheduler
 
 use core::ptr::Shared;
+use logging::*;
 
 /// task control block
 pub mod task;
@@ -37,8 +38,8 @@ static mut SCHEDULER: Option<scheduler::Scheduler> = None;
 /// Initialite module, must be called once, and only once
 pub fn init() {
 	unsafe {
+		debug!("initialize scheduler");
 		SCHEDULER = Some(scheduler::Scheduler::new());
-		debug!("scheduler initialized");
 	}
 }
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -38,7 +38,7 @@ static mut SCHEDULER: Option<scheduler::Scheduler> = None;
 pub fn init() {
 	unsafe {
 		SCHEDULER = Some(scheduler::Scheduler::new());
-		SCHEDULER.as_mut().unwrap().add_idle_task();
+		debug!("scheduler initialized");
 	}
 }
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -32,33 +32,34 @@ use core::ptr::Shared;
 pub mod task;
 mod scheduler;
 
-static mut SCHEDULER: scheduler::Scheduler = scheduler::Scheduler::new();
+static mut SCHEDULER: Option<scheduler::Scheduler> = None;
 
 /// Initialite module, must be called once, and only once
 pub fn init() {
 	unsafe {
-		SCHEDULER.add_idle_task();
+		SCHEDULER = Some(scheduler::Scheduler::new());
+		SCHEDULER.as_mut().unwrap().add_idle_task();
 	}
 }
 
 /// Create a new kernel task
 #[inline(always)]
 pub fn spawn(func: extern fn(), prio: task::Priority) -> task::TaskId {
-	unsafe { SCHEDULER.spawn(func, prio) }
+	unsafe { SCHEDULER.as_mut().unwrap().spawn(func, prio) }
 }
 
 /// Trigger the scheduler to switch to the next available task
 #[inline(always)]
 pub fn reschedule() {
 	unsafe {
-		SCHEDULER.reschedule()
+		SCHEDULER.as_mut().unwrap().reschedule()
 	}
 }
 
 #[inline(always)]
 pub fn number_of_tasks() -> usize {
 	unsafe {
-		SCHEDULER.number_of_tasks()
+		SCHEDULER.as_mut().unwrap().number_of_tasks()
 	}
 }
 
@@ -66,7 +67,7 @@ pub fn number_of_tasks() -> usize {
 #[inline(always)]
 pub fn schedule() {
 	unsafe {
-		SCHEDULER.schedule()
+		SCHEDULER.as_mut().unwrap().schedule()
 	}
 }
 
@@ -74,21 +75,21 @@ pub fn schedule() {
 #[inline(always)]
 pub fn block_current_task() -> Shared<task::Task> {
 	unsafe {
-		SCHEDULER.block_current_task()
+		SCHEDULER.as_mut().unwrap().block_current_task()
 	}
 }
 
 #[inline(always)]
 pub fn get_current_stack() -> (usize, usize) {
 	unsafe {
-		SCHEDULER.get_current_stack()
+		SCHEDULER.as_mut().unwrap().get_current_stack()
 	}
 }
 
 #[inline(always)]
 pub fn wakeup_task(task: Shared<task::Task>) {
 	unsafe {
-		SCHEDULER.wakeup_task(task)
+		SCHEDULER.as_mut().unwrap().wakeup_task(task)
 	}
 }
 
@@ -96,7 +97,7 @@ pub fn wakeup_task(task: Shared<task::Task>) {
 #[inline(always)]
 pub fn exit() -> ! {
 	unsafe {
-		SCHEDULER.exit()
+		SCHEDULER.as_mut().unwrap().exit()
 	}
 }
 
@@ -104,7 +105,7 @@ pub fn exit() -> ! {
 #[inline(always)]
 pub fn abort() -> ! {
 	unsafe {
-		SCHEDULER.abort()
+		SCHEDULER.as_mut().unwrap().abort()
 	}
 }
 
@@ -112,14 +113,14 @@ pub fn abort() -> ! {
 #[inline(always)]
 pub fn get_current_taskid() -> task::TaskId {
 	unsafe {
-		SCHEDULER.get_current_taskid()
+		SCHEDULER.as_mut().unwrap().get_current_taskid()
 	}
 }
 
 #[inline(always)]
 pub fn get_current_priority() -> task::Priority {
 	unsafe {
-		SCHEDULER.get_current_priority()
+		SCHEDULER.as_mut().unwrap().get_current_priority()
 	}
 }
 
@@ -127,6 +128,6 @@ pub fn get_current_priority() -> task::Priority {
 #[inline(always)]
 pub fn get_priority(id: task::TaskId) -> task::Priority {
 	unsafe {
-		SCHEDULER.get_priority(id)
+		SCHEDULER.as_mut().unwrap().get_priority(id)
 	}
 }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -39,15 +39,15 @@ extern {
 }
 
 pub struct Scheduler {
-	/// task id which is currently running
+	/// task which is currently running
 	current_task: Shared<Task>,
-	/// id of the idle task
+	/// idle task
 	idle_task: Shared<Task>,
 	/// queues of tasks, which are ready
 	ready_queue: SpinlockIrqSave<PriorityTaskQueue>,
 	/// queue of tasks, which are finished and can be released
 	finished_tasks: SpinlockIrqSave<Option<VecDeque<TaskId>>>,
-	/// map between task id and task controll block
+	/// map between task id and task control block
 	tasks: SpinlockIrqSave<Option<BTreeMap<TaskId, Shared<Task>>>>,
 	/// number of tasks managed by the scheduler
 	no_tasks: AtomicUsize

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -58,7 +58,7 @@ impl Scheduler {
 		let tid = TaskId::from(0);
 
 		// boot task is implicitly task 0 and and the idle task of core 0
-		let idle_box = Box::new(Task::new(tid, TaskStatus::TaskIdle, LOW_PRIO));
+		let idle_box = Box::new(Task::new(tid, TaskStatus::TaskIdle, IDLE_PRIO));
 		unsafe {
 
 			let rsp = (*idle_box.stack).bottom();

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -55,7 +55,7 @@ pub struct Scheduler {
 
 impl Scheduler {
 	/// Create a new scheduler
-	pub const fn new() -> Scheduler {
+	pub fn new() -> Scheduler {
 		Scheduler {
 			// I know that this is unsafe. But I know also that I initialize
 			// the Scheduler (with add_idle_task correctly) before the system schedules task.

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -256,8 +256,10 @@ pub struct Task {
 	pub id: TaskId,
 	/// Status of a task, e.g. if the task is ready or blocked
 	pub status: TaskStatus,
-	/// Task priority,
-	pub prio: Priority,
+	/// Task base priority,
+	pub base_prio: Priority,
+	/// Task scheduling penalty
+	pub penalty: u8,
 	/// Last stack pointer before a context switch to another task
 	pub last_stack_pointer: usize,
 	/// points to the next task within a task queue
@@ -288,7 +290,7 @@ impl Drop for Task {
 }
 
 impl Task {
-	pub fn new(tid: TaskId, task_status: TaskStatus, task_prio: Priority) -> Task {
+	pub fn new(tid: TaskId, task_status: TaskStatus, task_base_prio: Priority) -> Task {
 		let tmp1 = unsafe { Heap.alloc(Layout::new::<KernelStack>()).unwrap() as *mut KernelStack };
 		let tmp2 = unsafe { Heap.alloc(Layout::new::<KernelStack>()).unwrap() as *mut KernelStack };
 
@@ -297,7 +299,8 @@ impl Task {
 		Task {
 			id: tid,
 			status: task_status,
-			prio: task_prio,
+			base_prio: task_base_prio,
+			penalty: 0,
 			last_stack_pointer: 0,
 			next: None,
 			prev: None,
@@ -305,6 +308,9 @@ impl Task {
 			stack: tmp1,
 			ist: tmp2
 		}
+	}
+	pub fn prio(&self) -> Priority {
+		Priority::from(self.base_prio.into() + self.penalty)
 	}
 }
 


### PR DESCRIPTION
The major behavior changes:
* the scheduler is initialized, when `Scheduler::init` is called. Before it was static initialization.
* there is now multi-level feedback
* more priorities are used and the idle priority is special
