### PR TITLE
Disable interrupts before fetching a ticket in SpinlockIrqSave to guard against possible race conditions

### DIFF
--- a/src/synch/spinlock.rs
+++ b/src/synch/spinlock.rs
@@ -240,15 +240,14 @@ impl<T> SpinlockIrqSave<T>
 impl<T: ?Sized> SpinlockIrqSave<T>
 {
 	fn obtain_lock(&self) {
-		let ticket = self.queue.fetch_add(1, Ordering::SeqCst) + 1;
 		let irq = arch::irq::irq_nested_disable();
-		self.irq.store(irq, Ordering::SeqCst);
 
+		let ticket = self.queue.fetch_add(1, Ordering::SeqCst) + 1;
 		while self.dequeue.load(Ordering::SeqCst) != ticket {
-			arch::irq::irq_nested_enable(irq);
 			hint_core_should_pause();
-			arch::irq::irq_nested_disable();
 		}
+
+		self.irq.store(irq, Ordering::SeqCst);
 	}
 
 	pub fn lock(&self) -> SpinlockIrqSaveGuard<T>


### PR DESCRIPTION
To prevent a possible race condition, when fetching a ticket and being interrupted by an IRQ Handler that also fetches a ticket, we need to disable interrupts before fetching a ticket.

As discussed, I originally wanted to tackle this problem by implementing recursive spinlocks, just like in the C version of HermitCore. However, they would have also required disabling interrupts before fetching a ticket to be absolutely safe from race conditions. When interrupts are disabled early in obtain_lock() though, no recursive locking situation can happen inside eduOS-rs, so we can solve the race condition without introducing recursive spinlocks.